### PR TITLE
修复在windows英文环境下中文乱码的问题

### DIFF
--- a/src/BilibiliAutoLiver/nlog.config
+++ b/src/BilibiliAutoLiver/nlog.config
@@ -26,13 +26,14 @@
 					archiveFileName="${logDirectory}/${shortdate}_{#}.log"
 					archiveNumbering="Sequence"
 					archiveAboveSize="104857600"
-					layout="${date}|${uppercase:${level}}|${message}${onexception:inner=${newline} *****Error***** ${newline} ${exception:format=toString}${exception:format=StackTrace}}" />
+					layout="${date}|${uppercase:${level}}|${message}${onexception:inner=${newline} *****Error***** ${newline} ${exception:format=toString}${exception:format=StackTrace}}"
+					encoding="utf-8" />
 		</target>
 
 		<!-- Add this target to create a null target -->
 		<target xsi:type="Null" name="null" />
 		
-		<target xsi:type="ColoredConsole" name="all-console"
+		<target xsi:type="ColoredConsole" name="all-console" encoding="utf-8"
 				layout="${date}|${uppercase:${level}}|${message}${onexception:inner=${newline} *****Error***** ${newline} ${exception:format=toString}${exception:format=StackTrace}}">
 			<highlight-row condition="level == LogLevel.Debug" foregroundColor="DarkGray" />
 			<highlight-row condition="level == LogLevel.Info" foregroundColor="Gray" />


### PR DESCRIPTION
fix: 修复在windows英文环境下中文乱码的问题
modify: 修改nlog.config，配置字符集为utf-8

修复后的效果：
![image](https://github.com/user-attachments/assets/32f78f42-d6a4-4ee9-842b-cf8832c6ba3f)

由于我这里没有linux的机器，就没做linux的测试